### PR TITLE
Fix flags in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _NOTE_: If you have 2FA enabled, please make sure you set `PASSWORD=<password>:<
 ```
 mkdir -pv reddsaver/
 reddsaver --help
-reddsaver --e reddsaver.env -f reddsaver/
+reddsaver -e reddsaver.env -d reddsaver/
 ```
 
 NOTE: When running the application beyond the first time, if you use the directory as the initial run, the application will skip downloading the images that have already been downloaded.


### PR DESCRIPTION
The example invocation of `reddsaver` uses flags that don't seem to exist according to the `reddsaver --help` command. This PR changes those to match the real flags.

**Arguments changed:**
`--e` → `-e`  
`-f` → `-d`  