### PR TITLE
Bug fixes for URL/Media parsing; Bump to v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "reddsaver"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddsaver"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Manoj Karthick Selva Kumar <manojkarthick@ymail.com>"]
 description = "CLI tool to download saved media from Reddit"
 edition = "2018"
@@ -10,8 +10,6 @@ homepage = "https://github.com/manojkarthick/reddsaver"
 repository = "https://github.com/manojkarthick/reddsaver"
 keywords = ["cli", "reddit", "images"]
 categories = ["command-line-utilities"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 reqwest = { version = "0.10", features = ["json"] }

--- a/src/download.rs
+++ b/src/download.rs
@@ -347,119 +347,129 @@ async fn gfy_to_mp4(url: &str) -> Result<Option<String>, ReddSaverError> {
 /// Check if a particular URL contains supported media.
 async fn get_media(data: &PostData) -> Result<Vec<String>, ReddSaverError> {
     let original = data.url.as_ref().unwrap();
-    let mut parsed = Url::parse(original)?;
-    parsed.path_segments_mut().unwrap().pop_if_empty();
-    let url = &parsed[..Position::AfterPath];
-    let gallery_info = data.gallery_data.borrow();
     let mut media: Vec<String> = Vec::new();
 
-    // reddit images and gifs
-    if url.contains(REDDIT_IMAGE_SUBDOMAIN) {
-        // if the URL uses the reddit image subdomain and if the extension is
-        // jpg, png or gif, then we can use the URL as is.
-        if url.ends_with(JPG_EXTENSION)
-            || url.ends_with(PNG_EXTENSION)
-            || url.ends_with(GIF_EXTENSION)
-        {
-            let translated = String::from(url);
-            media.push(translated);
-        }
-    }
+    if let Ok(u) = Url::parse(original) {
+        let mut parsed = u.clone();
 
-    // reddit mp4 videos
-    if url.contains(REDDIT_VIDEO_SUBDOMAIN) {
-        // if the URL uses the reddit video subdomain and if the extension is
-        // mp4, then we can use the URL as is.
-        if url.ends_with(MP4_EXTENSION) {
-            let translated = String::from(url);
-            media.push(translated);
-        } else {
-            // if the URL uses the reddit video subdomain, but the link does not
-            // point directly to the mp4, then use the fallback URL to get the
-            // appropriate link. The video quality might range from 96p to 720p
-            if let Some(m) = &data.media {
-                if let Some(v) = &m.reddit_video {
-                    let translated = String::from(&v.fallback_url).replace("?source=fallback", "");
-                    media.push(translated);
-                }
-            }
-        }
-    }
+        match parsed.path_segments_mut() {
+            Ok(mut p) => p.pop_if_empty(),
+            Err(_) => return Ok(media),
+        };
 
-    // reddit image galleries
-    if url.contains(REDDIT_DOMAIN) && url.contains(REDDIT_GALLERY_PATH) {
-        if let Some(gallery) = gallery_info {
-            for item in gallery.items.iter() {
-                // extract the media ID from each gallery item and reconstruct the image URL
-                let translated = format!(
-                    "https://{}/{}.{}",
-                    REDDIT_IMAGE_SUBDOMAIN, item.media_id, JPG_EXTENSION
-                );
-                media.push(translated);
-            }
-        }
-    }
+        let url = &parsed[..Position::AfterPath];
+        let gallery_info = data.gallery_data.borrow();
 
-    // gfycat and redgifs
-    if url.contains(GFYCAT_DOMAIN) || url.contains(REDGIFS_DOMAIN) {
-        // if the Gfycat/Redgifs URL points directly to the mp4, download as is
-        if url.ends_with(MP4_EXTENSION) {
-            let translated = String::from(url);
-            media.push(translated);
-        } else {
-            // if the provided link is a gfycat post link, use the gfycat API
-            // to get the URL. gfycat likes to use lowercase names in their posts
-            // but the ID for the GIF is Pascal-cased. The case-conversion info
-            // can only be obtained from the API at the moment
-            if let Some(mp4_url) = gfy_to_mp4(url).await? {
-                media.push(mp4_url);
-            }
-        }
-    }
-
-    // giphy
-    if url.contains(GIPHY_DOMAIN) {
-        // giphy has multiple CDN networks named {media0, .., media5}
-        // links can point to the canonical media subdomain or any content domains
-        if url.contains(GIPHY_MEDIA_SUBDOMAIN)
-            || url.contains(GIPHY_MEDIA_SUBDOMAIN_0)
-            || url.contains(GIPHY_MEDIA_SUBDOMAIN_1)
-            || url.contains(GIPHY_MEDIA_SUBDOMAIN_2)
-            || url.contains(GIPHY_MEDIA_SUBDOMAIN_3)
-            || url.contains(GIPHY_MEDIA_SUBDOMAIN_4)
-        {
-            // if we encounter gif, mp4 or gifv - download as is
-            if url.ends_with(GIF_EXTENSION)
-                || url.ends_with(MP4_EXTENSION)
-                || url.ends_with(GIFV_EXTENSION)
+        // reddit images and gifs
+        if url.contains(REDDIT_IMAGE_SUBDOMAIN) {
+            // if the URL uses the reddit image subdomain and if the extension is
+            // jpg, png or gif, then we can use the URL as is.
+            if url.ends_with(JPG_EXTENSION)
+                || url.ends_with(PNG_EXTENSION)
+                || url.ends_with(GIF_EXTENSION)
             {
                 let translated = String::from(url);
                 media.push(translated);
             }
-        } else {
-            // if the link points to the giphy post rather than the media link,
-            // use the scheme below to get the actual URL for the gif.
-            let path = &parsed[Position::AfterHost..Position::AfterPath];
-            let media_id = path.split("-").last().unwrap();
-            let translated = format!("https://{}/media/{}.gif", GIPHY_MEDIA_SUBDOMAIN, media_id);
-            media.push(translated);
         }
-    }
 
-    // imgur
-    // NOTE: only support direct links for gifv and images
-    // *No* support for image and gallery posts.
-    if url.contains(IMGUR_DOMAIN) {
-        if url.contains(IMGUR_SUBDOMAIN) && url.ends_with(GIFV_EXTENSION) {
-            // if the extension is gifv, then replace gifv->mp4 to get the video URL
-            let translated = url.replace(GIFV_EXTENSION, MP4_EXTENSION);
-            media.push(translated);
+        // reddit mp4 videos
+        if url.contains(REDDIT_VIDEO_SUBDOMAIN) {
+            // if the URL uses the reddit video subdomain and if the extension is
+            // mp4, then we can use the URL as is.
+            if url.ends_with(MP4_EXTENSION) {
+                let translated = String::from(url);
+                media.push(translated);
+            } else {
+                // if the URL uses the reddit video subdomain, but the link does not
+                // point directly to the mp4, then use the fallback URL to get the
+                // appropriate link. The video quality might range from 96p to 720p
+                if let Some(m) = &data.media {
+                    if let Some(v) = &m.reddit_video {
+                        let translated =
+                            String::from(&v.fallback_url).replace("?source=fallback", "");
+                        media.push(translated);
+                    }
+                }
+            }
         }
-        if url.contains(IMGUR_SUBDOMAIN)
-            && (url.ends_with(PNG_EXTENSION) || url.ends_with(JPG_EXTENSION))
-        {
-            let translated = String::from(url);
-            media.push(translated);
+
+        // reddit image galleries
+        if url.contains(REDDIT_DOMAIN) && url.contains(REDDIT_GALLERY_PATH) {
+            if let Some(gallery) = gallery_info {
+                for item in gallery.items.iter() {
+                    // extract the media ID from each gallery item and reconstruct the image URL
+                    let translated = format!(
+                        "https://{}/{}.{}",
+                        REDDIT_IMAGE_SUBDOMAIN, item.media_id, JPG_EXTENSION
+                    );
+                    media.push(translated);
+                }
+            }
+        }
+
+        // gfycat and redgifs
+        if url.contains(GFYCAT_DOMAIN) || url.contains(REDGIFS_DOMAIN) {
+            // if the Gfycat/Redgifs URL points directly to the mp4, download as is
+            if url.ends_with(MP4_EXTENSION) {
+                let translated = String::from(url);
+                media.push(translated);
+            } else {
+                // if the provided link is a gfycat post link, use the gfycat API
+                // to get the URL. gfycat likes to use lowercase names in their posts
+                // but the ID for the GIF is Pascal-cased. The case-conversion info
+                // can only be obtained from the API at the moment
+                if let Some(mp4_url) = gfy_to_mp4(url).await? {
+                    media.push(mp4_url);
+                }
+            }
+        }
+
+        // giphy
+        if url.contains(GIPHY_DOMAIN) {
+            // giphy has multiple CDN networks named {media0, .., media5}
+            // links can point to the canonical media subdomain or any content domains
+            if url.contains(GIPHY_MEDIA_SUBDOMAIN)
+                || url.contains(GIPHY_MEDIA_SUBDOMAIN_0)
+                || url.contains(GIPHY_MEDIA_SUBDOMAIN_1)
+                || url.contains(GIPHY_MEDIA_SUBDOMAIN_2)
+                || url.contains(GIPHY_MEDIA_SUBDOMAIN_3)
+                || url.contains(GIPHY_MEDIA_SUBDOMAIN_4)
+            {
+                // if we encounter gif, mp4 or gifv - download as is
+                if url.ends_with(GIF_EXTENSION)
+                    || url.ends_with(MP4_EXTENSION)
+                    || url.ends_with(GIFV_EXTENSION)
+                {
+                    let translated = String::from(url);
+                    media.push(translated);
+                }
+            } else {
+                // if the link points to the giphy post rather than the media link,
+                // use the scheme below to get the actual URL for the gif.
+                let path = &parsed[Position::AfterHost..Position::AfterPath];
+                let media_id = path.split("-").last().unwrap();
+                let translated =
+                    format!("https://{}/media/{}.gif", GIPHY_MEDIA_SUBDOMAIN, media_id);
+                media.push(translated);
+            }
+        }
+
+        // imgur
+        // NOTE: only support direct links for gifv and images
+        // *No* support for image and gallery posts.
+        if url.contains(IMGUR_DOMAIN) {
+            if url.contains(IMGUR_SUBDOMAIN) && url.ends_with(GIFV_EXTENSION) {
+                // if the extension is gifv, then replace gifv->mp4 to get the video URL
+                let translated = url.replace(GIFV_EXTENSION, MP4_EXTENSION);
+                media.push(translated);
+            }
+            if url.contains(IMGUR_SUBDOMAIN)
+                && (url.ends_with(PNG_EXTENSION) || url.ends_with(JPG_EXTENSION))
+            {
+                let translated = String::from(url);
+                media.push(translated);
+            }
         }
     }
 


### PR DESCRIPTION
Changelog

* Skip downloading the media when one of the following occurs instead of exiting the application:
  * If the media URL cannot be resolved
  * If the response from the remote URL is invalid
  * If the response body cannot be encoded
  * If Image if the file cannot be created 
  * If title contains characters unsupported by the file system and human readable file names are used
* Bump version to v0.3.1
