### PR TITLE
Option to download upvoted posts and unsave/undo upvote

### DIFF
--- a/src/structures.rs
+++ b/src/structures.rs
@@ -42,7 +42,7 @@ pub struct UserAbout {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct UserSaved {
+pub struct Listing {
     /// The kind of object this is. eg: Comment, Account, Subreddit, etc.
     pub kind: String,
     /// Contains the data for the children of the listing.


### PR DESCRIPTION
* Use `--upvoted` flag to download media from upvoted posts instead of saved posts. Defaults to saved posts.
* The `--unsave` flag has been renamed to `--undo`. This flag unsaves the post or undoes the upvote based on the context (whether downloading upvoted or saved posts)

Closes #20 