### PR TITLE
Ignore responses with invalid response codes

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -427,6 +427,12 @@ async fn download_media(file_name: &str, url: &str) -> Result<bool, ReddSaverErr
     let maybe_response = reqwest::get(url).await;
     if let Ok(response) = maybe_response {
         debug!("URL Response: {:#?}", response);
+
+        if response.status() != 200 {
+            debug!("Invalid response code: {}, skipping {}", response.status(), url);
+            return Ok(false);
+        }
+
         let maybe_data = response.bytes().await;
         if let Ok(data) = maybe_data {
             debug!("Bytes length of the data: {:#?}", data.len());


### PR DESCRIPTION
In order not to clog downloaded content with stubs like attached one
![4qzuvn042xj41 jpg](https://user-images.githubusercontent.com/5128508/194151144-78ac62d8-3d45-49f4-8d60-0015c526a8d6.png)
