### PR TITLE
Fix undo for filtered subreddits

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -286,15 +286,14 @@ impl<'a> Downloader<'a> {
                                 entry.skipped += media_info.1;
                             }
                         }
+                        if self.undo {
+                            self.user.undo(post_name, listing_type).await?;
+                        }
                     } else {
                         debug!(
                             "Subreddit INVALID!: {} NOT present in {:#?}",
                             subreddit, self.subreddits
                         );
-                    }
-
-                    if self.undo {
-                        self.user.undo(post_name, listing_type).await?;
                     }
 
                     Ok::<(), ReddSaverError>(())


### PR DESCRIPTION
## Summary
- only run undo for posts that pass the subreddit filter
- keep existing undo behavior unchanged for unfiltered runs
