### PR TITLE
Remove destructive undo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ FLAGS:
     -r, --dry-run       Dry run and print the URLs of saved media to download
     -h, --help          Prints help information
     -s, --show-config   Show the current config being used
-    -U, --undo          Unsave or remove upvote for post after processing
     -u, --upvoted       Download media from upvoted posts
     -V, --version       Prints version information
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,17 +1,5 @@
-edition = "2018"
-# The "Default" setting has a heuristic which splits lines too aggresively.
+edition = "2021"
+# The "Default" setting has a heuristic which splits lines too aggressively.
 use_small_heuristics = "Max"
-# Prevent carriage returns
 newline_style = "Unix"
-# Reorder imports
 reorder_imports = true
-# Where to put binary operators in the line
-binop_separator = "Front"
-# Wrap comments into next line
-wrap_comments = true
-# Format string literals where necessary
-format_strings = true
-# Item layout inside a imports block
-imports_layout = "HorizontalVertical"
-# Indent on expressions or items.
-indent_style = "Block"

--- a/src/download.rs
+++ b/src/download.rs
@@ -18,7 +18,6 @@ use url::{Position, Url};
 use crate::errors::ReddSaverError;
 use crate::structures::{GfyData, PostData};
 use crate::structures::{Listing, SourceStats, Summary};
-use crate::user::{ListingType, User};
 use async_once::AsyncOnce;
 
 use crate::utils::{check_path_present, check_url_is_mp4, fetch_redgif_token, fetch_redgif_url};
@@ -101,13 +100,10 @@ struct SupportedMedia {
 
 #[derive(Debug)]
 pub struct Downloader<'a> {
-    user: &'a User<'a>,
     listing: &'a Vec<Listing>,
-    listing_type: &'a ListingType,
     data_directory: &'a str,
     subreddits: &'a Option<Vec<&'a str>>,
     should_download: bool,
-    undo: bool,
     ffmpeg_available: bool,
     ytdlp_available: bool,
 }
@@ -122,24 +118,18 @@ pub struct PostMetadata<'a> {
 
 impl<'a> Downloader<'a> {
     pub fn new(
-        user: &'a User,
         listing: &'a Vec<Listing>,
-        listing_type: &'a ListingType,
         data_directory: &'a str,
         subreddits: &'a Option<Vec<&'a str>>,
         should_download: bool,
-        undo: bool,
         ffmpeg_available: bool,
         ytdlp_available: bool,
     ) -> Downloader<'a> {
         Downloader {
-            user,
             listing,
-            listing_type,
             data_directory,
             subreddits,
             should_download,
-            undo,
             ffmpeg_available,
             ytdlp_available,
         }
@@ -149,8 +139,7 @@ impl<'a> Downloader<'a> {
         let mut full_summary = Summary::zero();
 
         for collection in self.listing {
-            full_summary =
-                full_summary.add(self.download_collection(collection, self.listing_type).await?);
+            full_summary = full_summary.add(self.download_collection(collection).await?);
         }
 
         info!("#####################################");
@@ -176,11 +165,7 @@ impl<'a> Downloader<'a> {
     }
 
     /// Download and save medias from Reddit in parallel
-    async fn download_collection(
-        &self,
-        collection: &Listing,
-        listing_type: &ListingType,
-    ) -> Result<Summary, ReddSaverError> {
+    async fn download_collection(&self, collection: &Listing) -> Result<Summary, ReddSaverError> {
         let summary = Arc::new(Mutex::new(Summary::zero()));
 
         collection
@@ -199,7 +184,6 @@ impl<'a> Downloader<'a> {
                     let subreddit = item.data.subreddit.borrow();
                     let post_author = item.data.author.borrow();
                     let post_id = item.data.id.borrow();
-                    let post_name = item.data.name.borrow();
 
                     let post_metadata =
                         PostMetadata { subreddit, author: post_author, id: post_id };
@@ -285,9 +269,6 @@ impl<'a> Downloader<'a> {
                                 entry.downloaded += media_info.0;
                                 entry.skipped += media_info.1;
                             }
-                        }
-                        if self.undo {
-                            self.user.undo(post_name, listing_type).await?;
                         }
                     } else {
                         debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,13 +71,6 @@ async fn main() -> Result<(), ReddSaverError> {
                 .action(ArgAction::SetTrue)
                 .help("Download media from upvoted posts"),
         )
-        .arg(
-            Arg::new("undo")
-                .short('U')
-                .long("undo")
-                .action(ArgAction::SetTrue)
-                .help("Unsave or remove upvote for post after processing"),
-        )
         .get_matches();
 
     let env_file = matches.get_one::<String>("environment").map(|s| s.as_str()).unwrap();
@@ -94,8 +87,6 @@ async fn main() -> Result<(), ReddSaverError> {
         matches.get_many::<String>("subreddits").map(|vals| vals.map(|s| s.as_str()).collect());
     let upvoted = matches.get_flag("upvoted");
     let listing_type = if upvoted { &ListingType::Upvoted } else { &ListingType::Saved };
-
-    let undo = matches.get_flag("undo");
 
     // initialize environment from the .env file
     dotenvy::from_filename(env_file).ok();
@@ -126,7 +117,6 @@ async fn main() -> Result<(), ReddSaverError> {
         info!("USER_AGENT = {}", &user_agent);
         info!("SUBREDDITS = {}", print_subreddits(&subreddits));
         info!("UPVOTED = {}", upvoted);
-        info!("UNDO = {}", undo);
         info!("FFMPEG AVAILABLE = {}", ffmpeg_available);
         info!("YT-DLP AVAILABLE = {}", ytdlp_available);
 
@@ -170,13 +160,10 @@ async fn main() -> Result<(), ReddSaverError> {
     debug!("Posts: {:#?}", listing);
 
     let downloader = Downloader::new(
-        &user,
         &listing,
-        &listing_type,
         &data_directory,
         &subreddits,
         should_download,
-        undo,
         ffmpeg_available,
         ytdlp_available,
     );

--- a/src/user.rs
+++ b/src/user.rs
@@ -4,7 +4,6 @@ use crate::structures::{Listing, UserAbout};
 use crate::utils::get_user_agent_string;
 use log::{debug, info};
 use reqwest::header::USER_AGENT;
-use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
@@ -111,34 +110,5 @@ impl<'a> User<'a> {
         }
 
         Ok(listing)
-    }
-
-    pub async fn undo(&self, name: &str, listing_type: &ListingType) -> Result<(), ReddSaverError> {
-        let client = reqwest::Client::new();
-        let url: String;
-        let mut map = HashMap::new();
-        map.insert("id", name);
-
-        match listing_type {
-            ListingType::Upvoted => {
-                url = format!("https://oauth.reddit.com/api/vote");
-                map.insert("dir", "0");
-            }
-            ListingType::Saved => {
-                url = format!("https://oauth.reddit.com/api/unsave");
-            }
-        }
-
-        let response = client
-            .post(&url)
-            .bearer_auth(&self.auth.access_token)
-            .header(USER_AGENT, get_user_agent_string(None, None))
-            .form(&map)
-            .send()
-            .await?;
-
-        debug!("Response: {:#?}", response);
-
-        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- remove the  CLI flag entirely
- delete the Reddit unsave/remove-upvote code path
- update the README command reference to match the new CLI surface

## Why
The existing undo behavior is destructive and too risky to keep. Even with additional conditions, it still modifies user Reddit state and can lead to data loss if expectations and actual behavior diverge.

This change switches reddsaver to a non-destructive workflow so it only downloads media and never unsaves saved posts or removes upvotes.

Closes #35.