### PR TITLE
Auto-create data directory if it does not exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fs;
 use std::process::ExitCode;
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
@@ -9,7 +10,6 @@ use auth::Client;
 
 use crate::download::Downloader;
 use crate::errors::ReddSaverError;
-use crate::errors::ReddSaverError::DataDirNotFound;
 use crate::user::{ListingType, User};
 use crate::utils::*;
 
@@ -123,9 +123,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     let password = required_env.password;
     let user_agent = get_user_agent_string(None, None);
 
-    if !check_path_present(&data_directory) {
-        return Err(DataDirNotFound);
-    }
+    ensure_data_directory(&data_directory)?;
 
     // if the option is show-config, show the configuration and return immediately
     if matches.get_flag("show_config") {
@@ -260,6 +258,14 @@ where
     }
 }
 
+fn ensure_data_directory(path: &str) -> Result<(), ReddSaverError> {
+    if !check_path_present(path) {
+        info!("Data directory not found, creating {}", path);
+        fs::create_dir_all(path)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -267,7 +273,39 @@ mod tests {
     use std::io::Write;
 
     use super::*;
-    use tempfile::NamedTempFile;
+    use tempfile::{tempdir, NamedTempFile};
+
+    #[test]
+    fn creates_missing_data_directory() {
+        let parent = tempdir().unwrap();
+        let new_dir = parent.path().join("data");
+        assert!(!new_dir.exists());
+
+        ensure_data_directory(new_dir.to_str().unwrap()).unwrap();
+
+        assert!(new_dir.exists());
+    }
+
+    #[test]
+    fn does_not_fail_when_data_directory_already_exists() {
+        let dir = tempdir().unwrap();
+        assert!(dir.path().exists());
+
+        ensure_data_directory(dir.path().to_str().unwrap()).unwrap();
+
+        assert!(dir.path().exists());
+    }
+
+    #[test]
+    fn creates_nested_data_directory() {
+        let parent = tempdir().unwrap();
+        let nested = parent.path().join("a").join("b").join("c");
+        assert!(!nested.exists());
+
+        ensure_data_directory(nested.to_str().unwrap()).unwrap();
+
+        assert!(nested.exists());
+    }
 
     #[test]
     fn loads_required_env_when_all_values_are_present() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -141,6 +141,25 @@ pub async fn fetch_redgif_url(
     Ok(Some(response))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn check_path_present_returns_true_for_existing_directory() {
+        let dir = tempdir().unwrap();
+        assert!(check_path_present(dir.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn check_path_present_returns_false_for_nonexistent_path() {
+        let dir = tempdir().unwrap();
+        let nonexistent = dir.path().join("does-not-exist");
+        assert!(!check_path_present(nonexistent.to_str().unwrap()));
+    }
+}
+
 /// Check if the given URL contains an MP4 track using the content type
 pub async fn check_url_is_mp4(url: &str) -> Result<Option<bool>, ReddSaverError> {
     let response = reqwest::get(url).await?;


### PR DESCRIPTION
## Summary

- Replaces the hard error when the data directory is missing with an automatic `fs::create_dir_all` call, so the CLI creates the directory (and any missing parents) instead of aborting
- Extracts the logic into `ensure_data_directory` to keep `run()` readable and to make the behaviour unit-testable

## Test plan

- [ ] `creates_missing_data_directory` — verifies the directory is created when absent
- [ ] `does_not_fail_when_data_directory_already_exists` — verifies no error when the directory is already present
- [ ] `creates_nested_data_directory` — verifies deep paths (`a/b/c`) are created correctly
- [ ] `check_path_present_returns_true_for_existing_directory` — existing path returns `true`
- [ ] `check_path_present_returns_false_for_nonexistent_path` — missing path returns `false`
- [ ] Run `cargo test` locally — all 11 tests pass