### PR TITLE
Fix missing downloads for .jpeg, .webp, and non-JPG gallery images

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -22,9 +22,8 @@ use async_once::AsyncOnce;
 
 use crate::utils::{check_path_present, check_url_is_mp4, fetch_redgif_token, fetch_redgif_url};
 
-static JPG_EXTENSION: &str = "jpg";
-static PNG_EXTENSION: &str = "png";
 static GIF_EXTENSION: &str = "gif";
+static IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
 static GIFV_EXTENSION: &str = "gifv";
 static MP4_EXTENSION: &str = "mp4";
 
@@ -733,8 +732,8 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
         // reddit images and gifs
         if url.contains(REDDIT_IMAGE_SUBDOMAIN) {
             // if the URL uses the reddit image subdomain and if the extension is
-            // jpg, png or gif, then we can use the URL as is.
-            if url.ends_with(JPG_EXTENSION) || url.ends_with(PNG_EXTENSION) {
+            // a supported image format (jpg, jpeg, png, webp), then we can use the URL as is.
+            if IMAGE_EXTENSIONS.iter().any(|ext| url.ends_with(ext)) {
                 let translated = String::from(url);
                 let supported_media = SupportedMedia {
                     components: vec![translated],
@@ -783,10 +782,19 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
                 // collect all the URLs for the images in the album
                 let mut image_urls = Vec::new();
                 for item in gallery.items.iter() {
-                    // extract the media ID from each gallery item and reconstruct the image URL
+                    // derive the extension from media_metadata ("m" is the MIME type,
+                    // e.g. "image/jpg", "image/png", "image/webp"). Fall back to "jpg".
+                    let ext = data.media_metadata
+                        .as_ref()
+                        .and_then(|mm| mm.get(&item.media_id))
+                        .and_then(|v| v.get("m"))
+                        .and_then(|m| m.as_str())
+                        .and_then(|mime| mime.split('/').last())
+                        .map(|sub| if sub == "jpeg" { "jpg" } else { sub })
+                        .unwrap_or("jpg");
                     let image_url = format!(
                         "https://{}/{}.{}",
-                        REDDIT_IMAGE_SUBDOMAIN, item.media_id, JPG_EXTENSION
+                        REDDIT_IMAGE_SUBDOMAIN, item.media_id, ext
                     );
                     image_urls.push(image_url);
                 }
@@ -872,7 +880,7 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
                 media.push(supported_media);
             }
             if url.contains(IMGUR_SUBDOMAIN)
-                && (url.ends_with(PNG_EXTENSION) || url.ends_with(JPG_EXTENSION))
+                && IMAGE_EXTENSIONS.iter().any(|ext| url.ends_with(ext))
             {
                 let supported_media = SupportedMedia {
                     components: vec![String::from(url)],

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -116,6 +116,9 @@ pub struct PostData {
     pub created_utc: Value,
     /// Gallery metadata
     pub gallery_data: Option<GalleryItems>,
+    /// Per-item metadata for gallery posts, keyed by media_id.
+    /// Each entry contains (among other fields) "m": the MIME type (e.g. "image/jpg").
+    pub media_metadata: Option<HashMap<String, Value>>,
     /// Is post a video?
     pub is_video: Option<bool>,
     /// Reddit Media info


### PR DESCRIPTION
## Summary

- **Root cause**: image detection only checked for `.jpg` and `.png` extensions; Reddit now also serves images as `.jpeg` and `.webp`, which were silently skipped
- Replace individual extension constants with an `IMAGE_EXTENSIONS` slice `["jpg", "jpeg", "png", "webp"]` and switch both the `i.redd.it` and `i.imgur.com` checks to use `.iter().any()`
- Parse `media_metadata` from the Reddit API response (new field on `PostData`) and use it to derive the correct per-item file extension for gallery posts, rather than hardcoding `.jpg` for every gallery item

## Test plan

- [x] Run against a saved list containing a `.jpeg` post (e.g. post `1rezfxx`) and confirm it is downloaded
- [x] Confirm gallery posts with mixed image formats (PNG, WebP) download all items with correct extensions
- [x] Confirm existing `.jpg` / `.png` / `.gif` posts still download correctly
- [x] Check download summary counts are unchanged for already-downloaded media (skipped, not re-downloaded)
