### PR TITLE
feat: add subreddit feed mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -140,6 +141,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -380,6 +393,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ env_logger = "0.11"
 futures = "0.3.8"
 rand = "0.8"
 random-names = "0.1.3"
-clap = { version = "4", features = ["cargo"] }
+clap = { version = "4", features = ["cargo", "derive"] }
 url = "2.2.0"
 tempfile = "3.2.0"
 which = "4.2.2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reddsaver ![build](https://github.com/manojkarthick/reddsaver/workflows/build/badge.svg) [![Crates.io](https://img.shields.io/crates/v/reddsaver.svg)](https://crates.io/crates/reddsaver)
 
-Command line tool to download saved/upvoted media from Reddit.
+Command line tool to download saved, upvoted, or subreddit feed media from Reddit.
 
 **Supported sources:**
 | Source | Media types |
@@ -118,16 +118,30 @@ mkdir -pv data/
 # Verify the configuration is correct
 reddsaver -e reddsaver.env -d data --show-config
 
-# Download saved media
+# Download saved media (default)
 reddsaver -e reddsaver.env -d data
 
 # Download upvoted media instead
 reddsaver -e reddsaver.env -d data --upvoted
+# or equivalently:
+reddsaver -e reddsaver.env -d data --mode upvoted
+
+# Download from a subreddit's hot feed (default listing type, limit 1000)
+reddsaver -e reddsaver.env -d data --mode feed --subreddits pics
+
+# Download top posts of the week from multiple subreddits (500 per subreddit)
+reddsaver -e reddsaver.env -d data --mode feed --subreddits pics,aww --listing-type top --time-filter week --limit 500
+
+# Download new posts from a subreddit
+reddsaver -e reddsaver.env -d data --mode feed --subreddits earthporn --listing-type new
+
+# Limit saved/upvoted downloads
+reddsaver -e reddsaver.env -d data --limit 200
 
 # Dry run — print URLs without downloading
 reddsaver -e reddsaver.env -d data --dry-run
 
-# Restrict to specific subreddits
+# Restrict saved/upvoted downloads to specific subreddits
 reddsaver -e reddsaver.env -d data --subreddits pics,aww,videos
 ```
 
@@ -136,25 +150,45 @@ On subsequent runs, files that already exist in the data directory are skipped a
 ## Command line reference
 
 ```
-ReddSaver 1.0.0
-Manoj Karthick Selva Kumar
 Simple CLI tool to download saved media from Reddit
 
-USAGE:
-    reddsaver [FLAGS] [OPTIONS]
+Usage: reddsaver [OPTIONS]
 
-FLAGS:
-    -r, --dry-run       Dry run and print the URLs of saved media to download
-    -h, --help          Prints help information
-    -s, --show-config   Show the current config being used
-    -u, --upvoted       Download media from upvoted posts
-    -V, --version       Prints version information
-
-OPTIONS:
-    -d, --data-dir <DATA_DIR>           Directory to save the media to [default: data]
-    -e, --from-env <ENV_FILE>           Set a custom .env style file with secrets [default: .env]
-    -S, --subreddits <SUBREDDITS>...    Download media from these subreddits only
+Options:
+  -e, --from-env <ENV_FILE>      Set a custom .env style file with secrets [default: .env]
+  -d, --data-dir <DATA_DIR>      Directory to save the media to [default: data]
+  -s, --show-config              Show the current config being used
+  -r, --dry-run                  Dry run and print the URLs of saved media to download
+  -S, --subreddits <SUBREDDITS>  Subreddits to filter (saved/upvoted) or fetch from (feed mode)
+  -u, --upvoted                  Download media from upvoted posts (alias for --mode upvoted)
+  -m, --mode <MODE>              Operation mode [default: saved] [possible values: saved, upvoted, feed]
+  -t, --listing-type <TYPE>      Subreddit listing sort [default: hot] [possible values: hot, top, new, controversial]
+  -T, --time-filter <PERIOD>     Time period for top/controversial listings [default: all] [possible values: hour, day, week, month, year, all]
+  -l, --limit <LIMIT>            Max posts to process per source (default: unlimited for saved/upvoted, 1000 for feed)
+  -h, --help                     Print help
+  -V, --version                  Print version
 ```
+
+### Modes
+
+| Mode | Flag | Description |
+|------|------|-------------|
+| `saved` | `--mode saved` (default) | Download media from your saved posts |
+| `upvoted` | `--mode upvoted` or `--upvoted` | Download media from your upvoted posts |
+| `feed` | `--mode feed` | Download media from a subreddit's listing feed |
+
+### Feed mode options
+
+`--listing-type` and `--time-filter` are only valid with `--mode feed`. `--subreddits` is required in feed mode and specifies which subreddit(s) to fetch from. The `--limit` defaults to **1000 per subreddit**.
+
+| Listing type | Time filter applies? | Description |
+|---|---|---|
+| `hot` (default) | No | Currently trending posts |
+| `top` | Yes | Highest-scoring posts in the given time period |
+| `new` | No | Most recently submitted posts |
+| `controversial` | Yes | Most controversial posts in the given time period |
+
+Time filter values for `top` and `controversial`: `hour`, `day`, `week`, `month`, `year`, `all` (default `all`).
 
 ## File naming
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ reddsaver -e reddsaver.env -d data --show-config
 reddsaver -e reddsaver.env -d data
 
 # Download upvoted media instead
-reddsaver -e reddsaver.env -d data --upvoted
-# or equivalently:
 reddsaver -e reddsaver.env -d data --mode upvoted
 
 # Download from a subreddit's hot feed (default listing type, limit 1000)
@@ -160,7 +158,6 @@ Options:
   -s, --show-config              Show the current config being used
   -r, --dry-run                  Dry run and print the URLs of saved media to download
   -S, --subreddits <SUBREDDITS>  Subreddits to filter (saved/upvoted) or fetch from (feed mode)
-  -u, --upvoted                  Download media from upvoted posts (alias for --mode upvoted)
   -m, --mode <MODE>              Operation mode [default: saved] [possible values: saved, upvoted, feed]
   -t, --listing-type <TYPE>      Subreddit listing sort [default: hot] [possible values: hot, top, new, controversial]
   -T, --time-filter <PERIOD>     Time period for top/controversial listings [default: all] [possible values: hour, day, week, month, year, all]
@@ -174,7 +171,7 @@ Options:
 | Mode | Flag | Description |
 |------|------|-------------|
 | `saved` | `--mode saved` (default) | Download media from your saved posts |
-| `upvoted` | `--mode upvoted` or `--upvoted` | Download media from your upvoted posts |
+| `upvoted` | `--mode upvoted` | Download media from your upvoted posts |
 | `feed` | `--mode feed` | Download media from a subreddit's listing feed |
 
 ### Feed mode options

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ reddsaver -e reddsaver.env -d data
 # Download upvoted media instead
 reddsaver -e reddsaver.env -d data --mode upvoted
 
-# Download from a subreddit's hot feed (default listing type, limit 1000)
+# Download from a subreddit's hot feed (default listing type, limit 500)
 reddsaver -e reddsaver.env -d data --mode feed --subreddits pics
 
 # Download top posts of the week from multiple subreddits (500 per subreddit)
@@ -132,6 +132,12 @@ reddsaver -e reddsaver.env -d data --mode feed --subreddits pics,aww --listing-t
 
 # Download new posts from a subreddit
 reddsaver -e reddsaver.env -d data --mode feed --subreddits earthporn --listing-type new
+
+# Download a subreddit's best feed
+reddsaver -e reddsaver.env -d data --mode feed --subreddits pics --listing-type best
+
+# Download rising posts from a subreddit
+reddsaver -e reddsaver.env -d data --mode feed --subreddits pics --listing-type rising
 
 # Limit saved/upvoted downloads
 reddsaver -e reddsaver.env -d data --limit 200
@@ -159,9 +165,9 @@ Options:
   -r, --dry-run                  Dry run and print the URLs of saved media to download
   -S, --subreddits <SUBREDDITS>  Subreddits to filter (saved/upvoted) or fetch from (feed mode)
   -m, --mode <MODE>              Operation mode [default: saved] [possible values: saved, upvoted, feed]
-  -t, --listing-type <TYPE>      Subreddit listing sort [default: hot] [possible values: hot, top, new, controversial]
+  -t, --listing-type <TYPE>      Subreddit listing sort [default: hot] [possible values: hot, best, rising, top, new, controversial]
   -T, --time-filter <PERIOD>     Time period for top/controversial listings [default: all] [possible values: hour, day, week, month, year, all]
-  -l, --limit <LIMIT>            Max posts to process per source (default: unlimited for saved/upvoted, 1000 for feed)
+  -l, --limit <LIMIT>            Max posts to process per source (default: unlimited for saved/upvoted, 500 for feed)
   -h, --help                     Print help
   -V, --version                  Print version
 ```
@@ -176,16 +182,18 @@ Options:
 
 ### Feed mode options
 
-`--listing-type` and `--time-filter` are only valid with `--mode feed`. `--subreddits` is required in feed mode and specifies which subreddit(s) to fetch from. The `--limit` defaults to **1000 per subreddit**.
+`--listing-type` and `--time-filter` are only valid with `--mode feed`. `--subreddits` is required in feed mode and specifies which subreddit(s) to fetch from. The `--limit` defaults to **500 per subreddit**.
 
 | Listing type | Time filter applies? | Description |
 |---|---|---|
 | `hot` (default) | No | Currently trending posts |
+| `best` | No | Reddit's best-ranked posts for the subreddit |
+| `rising` | No | Posts currently gaining traction in the subreddit |
 | `top` | Yes | Highest-scoring posts in the given time period |
 | `new` | No | Most recently submitted posts |
 | `controversial` | Yes | Most controversial posts in the given time period |
 
-Time filter values for `top` and `controversial`: `hour`, `day`, `week`, `month`, `year`, `all` (default `all`).
+Time filter values for `top` and `controversial`: `hour`, `day`, `week`, `month`, `year`, `all` (default `all`). If `--time-filter` is passed with `hot`, `best`, `rising`, or `new`, the value is ignored.
 
 ## File naming
 
@@ -213,6 +221,18 @@ Given any file downloaded by reddsaver, prints the subreddit, username, and a di
 # Subreddit: aww
 # Username:  thunderbird42
 # Post link: https://www.reddit.com/r/aww/comments/abc123/
+```
+
+### download_top_presets.sh
+
+Runs a common set of `top` downloads for a single subreddit:
+- `all` with limit `1000`
+- `year` with limit `500`
+- `month` with limit `250`
+- `day` with limit `25`
+
+```shell
+./scripts/download_top_presets.sh --env-file zzxx.env --subreddit SkinnyWithAbs --data-dir ~/Downloads/Reddit
 ```
 
 ## Download summary

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,4 +39,6 @@ pub enum ReddSaverError {
     ToStringConversionError(#[from] ToStrError),
     #[error("Could not convert from string")]
     FromStringConversionError(#[from] FromStrError),
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,14 +153,10 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     // Validate that listing-type / time-filter are not used outside feed mode.
     // We detect "explicit" use by checking whether the value differs from the default.
     if effective_mode != "feed" {
-        let listing_type_explicit =
-            matches.get_one::<String>("listing_type").map(|s| s.as_str()) != Some("hot")
-                && matches.value_source("listing_type")
-                    == Some(clap::parser::ValueSource::CommandLine);
-        let time_filter_explicit =
-            matches.get_one::<String>("time_filter").map(|s| s.as_str()) != Some("all")
-                && matches.value_source("time_filter")
-                    == Some(clap::parser::ValueSource::CommandLine);
+        let listing_type_explicit = listing_type_str != "hot"
+            && matches.value_source("listing_type") == Some(clap::parser::ValueSource::CommandLine);
+        let time_filter_explicit = time_filter_str != "all"
+            && matches.value_source("time_filter") == Some(clap::parser::ValueSource::CommandLine);
 
         if listing_type_explicit {
             return Err(ReddSaverError::InvalidArgument(

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn cli() -> Command {
                 .long("limit")
                 .value_name("LIMIT")
                 .value_parser(clap::value_parser!(usize))
-                .help("Max posts to process per source (default: unlimited for saved/upvoted, 1000 for feed)"),
+                .help("Max posts to process per source (default: unlimited for saved/upvoted, 500 for feed)"),
         )
 }
 
@@ -149,12 +149,12 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     let time_filter = matches.get_one::<TimePeriod>("time_filter").cloned().unwrap_or(TimePeriod::All);
 
     // Validate that listing-type / time-filter are not used outside feed mode.
-    // We detect "explicit" use by checking whether the value differs from the default.
+    // For time-filter, we only care whether the user passed the flag explicitly.
     if mode != Mode::Feed {
         let listing_type_explicit = listing_type != SubredditSort::Hot
             && matches.value_source("listing_type") == Some(clap::parser::ValueSource::CommandLine);
-        let time_filter_explicit = time_filter != TimePeriod::All
-            && matches.value_source("time_filter") == Some(clap::parser::ValueSource::CommandLine);
+        let time_filter_explicit =
+            matches.value_source("time_filter") == Some(clap::parser::ValueSource::CommandLine);
 
         if listing_type_explicit {
             return Err(ReddSaverError::InvalidArgument(
@@ -175,10 +175,19 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
         ));
     }
 
+    let time_filter_explicit =
+        matches.value_source("time_filter") == Some(clap::parser::ValueSource::CommandLine);
+    if mode == Mode::Feed
+        && time_filter_explicit
+        && !matches!(listing_type, SubredditSort::Top | SubredditSort::Controversial)
+    {
+        warn!("--time-filter is only supported for top and controversial listing types, ignoring.");
+    }
+
     // Determine effective limit
     let explicit_limit: Option<usize> = matches.get_one::<usize>("limit").copied();
     let effective_limit: Option<usize> = match mode {
-        Mode::Feed => Some(explicit_limit.unwrap_or(1000)),
+        Mode::Feed => Some(explicit_limit.unwrap_or(500)),
         _ => explicit_limit, // None means unlimited for saved/upvoted
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
 
     info!("Starting data gathering from Reddit. This might take some time. Hold on....");
 
-    let (listing, downloader_subreddits) = match mode {
+    let listing = match &mode {
         Mode::Feed => {
             let subreddits_list = subreddits.as_ref().unwrap();
             let limit = effective_limit.unwrap(); // always Some in feed mode
@@ -264,25 +264,24 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
                     user.subreddit_listing(sub, &listing_type, period, limit).await?;
                 all_listings.append(&mut sub_listing);
             }
-            // subreddits filter not needed — we already fetched per-subreddit
-            (all_listings, None)
+            all_listings
         }
-        Mode::Saved => {
-            let listing = user.listing(&ListingType::Saved, effective_limit).await?;
-            (listing, subreddits)
-        }
-        Mode::Upvoted => {
-            let listing = user.listing(&ListingType::Upvoted, effective_limit).await?;
-            (listing, subreddits)
-        }
+        Mode::Saved => user.listing(&ListingType::Saved, effective_limit).await?,
+        Mode::Upvoted => user.listing(&ListingType::Upvoted, effective_limit).await?,
     };
 
     debug!("Posts: {:#?}", listing);
 
+    // In feed mode subreddits were used as sources; no further filtering is needed
+    let subreddit_filter = match mode {
+        Mode::Feed => None,
+        _ => subreddits,
+    };
+
     let downloader = Downloader::new(
         &listing,
         &data_directory,
-        &downloader_subreddits,
+        &subreddit_filter,
         should_download,
         ffmpeg_available,
         ytdlp_available,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use auth::Client;
 
 use crate::download::Downloader;
 use crate::errors::ReddSaverError;
-use crate::user::{ListingType, SubredditSort, TimePeriod, User};
+use crate::user::{ListingType, Mode, SubredditSort, TimePeriod, User};
 use crate::utils::*;
 
 mod auth;
@@ -95,7 +95,7 @@ fn cli() -> Command {
                 .short('m')
                 .long("mode")
                 .value_name("MODE")
-                .value_parser(["saved", "upvoted", "feed"])
+                .value_parser(clap::value_parser!(Mode))
                 .default_value("saved")
                 .help("Operation mode"),
         )
@@ -142,7 +142,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     let subreddits: Option<Vec<&str>> =
         matches.get_many::<String>("subreddits").map(|vals| vals.map(|s| s.as_str()).collect());
 
-    let effective_mode = matches.get_one::<String>("mode").map(|s| s.as_str()).unwrap_or("saved");
+    let mode = matches.get_one::<Mode>("mode").cloned().unwrap_or(Mode::Saved);
 
     // Parse listing-type and time-filter (only meaningful in feed mode)
     let listing_type = matches.get_one::<SubredditSort>("listing_type").cloned().unwrap_or(SubredditSort::Hot);
@@ -150,7 +150,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
 
     // Validate that listing-type / time-filter are not used outside feed mode.
     // We detect "explicit" use by checking whether the value differs from the default.
-    if effective_mode != "feed" {
+    if mode != Mode::Feed {
         let listing_type_explicit = listing_type != SubredditSort::Hot
             && matches.value_source("listing_type") == Some(clap::parser::ValueSource::CommandLine);
         let time_filter_explicit = time_filter != TimePeriod::All
@@ -169,7 +169,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     }
 
     // In feed mode, --subreddits is required
-    if effective_mode == "feed" && subreddits.is_none() {
+    if mode == Mode::Feed && subreddits.is_none() {
         return Err(ReddSaverError::InvalidArgument(
             "--mode feed requires at least one subreddit via --subreddits".to_string(),
         ));
@@ -177,8 +177,8 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
 
     // Determine effective limit
     let explicit_limit: Option<usize> = matches.get_one::<usize>("limit").copied();
-    let effective_limit: Option<usize> = match effective_mode {
-        "feed" => Some(explicit_limit.unwrap_or(1000)),
+    let effective_limit: Option<usize> = match mode {
+        Mode::Feed => Some(explicit_limit.unwrap_or(1000)),
         _ => explicit_limit, // None means unlimited for saved/upvoted
     };
 
@@ -207,7 +207,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
         info!("REDDSAVER_PASSWORD = {}", mask_sensitive(&password));
         info!("USER_AGENT = {}", &user_agent);
         info!("SUBREDDITS = {}", print_subreddits(&subreddits));
-        info!("MODE = {}", effective_mode);
+        info!("MODE = {}", mode);
         info!("LISTING_TYPE = {}", listing_type);
         info!("TIME_FILTER = {}", time_filter);
         info!(
@@ -253,10 +253,10 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
 
     info!("Starting data gathering from Reddit. This might take some time. Hold on....");
 
-    let (listing, downloader_subreddits) = match effective_mode {
-        "feed" => {
+    let (listing, downloader_subreddits) = match mode {
+        Mode::Feed => {
             let subreddits_list = subreddits.as_ref().unwrap();
-            let limit = effective_limit.unwrap(); // always Some in subreddit mode
+            let limit = effective_limit.unwrap(); // always Some in feed mode
             let mut all_listings = Vec::new();
             for sub in subreddits_list {
                 info!("Fetching r/{} ({}, limit {})", sub, listing_type, limit);
@@ -267,13 +267,12 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
             // subreddits filter not needed — we already fetched per-subreddit
             (all_listings, None)
         }
-        _ => {
-            let listing_type = if effective_mode == "upvoted" {
-                ListingType::Upvoted
-            } else {
-                ListingType::Saved
-            };
-            let listing = user.listing(&listing_type, effective_limit).await?;
+        Mode::Saved => {
+            let listing = user.listing(&ListingType::Saved, effective_limit).await?;
+            (listing, subreddits)
+        }
+        Mode::Upvoted => {
+            let listing = user.listing(&ListingType::Upvoted, effective_limit).await?;
             (listing, subreddits)
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,13 +91,6 @@ fn cli() -> Command {
                 .help("Download media from these subreddits only"),
         )
         .arg(
-            Arg::new("upvoted")
-                .short('u')
-                .long("upvoted")
-                .action(ArgAction::SetTrue)
-                .help("Download media from upvoted posts (alias for --mode upvoted)"),
-        )
-        .arg(
             Arg::new("mode")
                 .short('m')
                 .long("mode")
@@ -149,17 +142,7 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     let subreddits: Option<Vec<&str>> =
         matches.get_many::<String>("subreddits").map(|vals| vals.map(|s| s.as_str()).collect());
 
-    // Resolve mode: --upvoted flag is a backwards-compatible alias for --mode upvoted.
-    let upvoted_flag = matches.get_flag("upvoted");
-    let mode_str = matches.get_one::<String>("mode").map(|s| s.as_str()).unwrap_or("saved");
-
-    if upvoted_flag && mode_str == "feed" {
-        return Err(ReddSaverError::InvalidArgument(
-            "--upvoted and --mode feed are mutually exclusive".to_string(),
-        ));
-    }
-
-    let effective_mode = if upvoted_flag { "upvoted" } else { mode_str };
+    let effective_mode = matches.get_one::<String>("mode").map(|s| s.as_str()).unwrap_or("saved");
 
     // Parse listing-type and time-filter (only meaningful in feed mode)
     let listing_type_str =

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use auth::Client;
 
 use crate::download::Downloader;
 use crate::errors::ReddSaverError;
-use crate::user::{ListingType, User};
+use crate::user::{ListingType, SubredditSort, TimePeriod, User};
 use crate::utils::*;
 
 mod auth;
@@ -95,7 +95,42 @@ fn cli() -> Command {
                 .short('u')
                 .long("upvoted")
                 .action(ArgAction::SetTrue)
-                .help("Download media from upvoted posts"),
+                .help("Download media from upvoted posts (alias for --mode upvoted)"),
+        )
+        .arg(
+            Arg::new("mode")
+                .short('m')
+                .long("mode")
+                .value_name("MODE")
+                .value_parser(["saved", "upvoted", "feed"])
+                .default_value("saved")
+                .help("Operation mode"),
+        )
+        .arg(
+            Arg::new("listing_type")
+                .short('t')
+                .long("listing-type")
+                .value_name("TYPE")
+                .value_parser(["hot", "top", "new", "controversial"])
+                .default_value("hot")
+                .help("Subreddit listing sort"),
+        )
+        .arg(
+            Arg::new("time_filter")
+                .short('T')
+                .long("time-filter")
+                .value_name("PERIOD")
+                .value_parser(["hour", "day", "week", "month", "year", "all"])
+                .default_value("all")
+                .help("Time period for top/controversial listings"),
+        )
+        .arg(
+            Arg::new("limit")
+                .short('l')
+                .long("limit")
+                .value_name("LIMIT")
+                .value_parser(clap::value_parser!(usize))
+                .help("Max posts to process per source (default: unlimited for saved/upvoted, 1000 for feed)"),
         )
 }
 
@@ -110,11 +145,84 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     let ffmpeg_available = application_present(String::from("ffmpeg"));
     // check if yt-dlp is present on the system
     let ytdlp_available = application_present(String::from("yt-dlp"));
-    // restrict downloads to these subreddits
+    // restrict downloads to these subreddits (filter for saved/upvoted; source for feed mode)
     let subreddits: Option<Vec<&str>> =
         matches.get_many::<String>("subreddits").map(|vals| vals.map(|s| s.as_str()).collect());
-    let upvoted = matches.get_flag("upvoted");
-    let listing_type = if upvoted { &ListingType::Upvoted } else { &ListingType::Saved };
+
+    // Resolve mode: --upvoted flag is a backwards-compatible alias for --mode upvoted.
+    let upvoted_flag = matches.get_flag("upvoted");
+    let mode_str = matches.get_one::<String>("mode").map(|s| s.as_str()).unwrap_or("saved");
+
+    if upvoted_flag && mode_str == "feed" {
+        return Err(ReddSaverError::InvalidArgument(
+            "--upvoted and --mode feed are mutually exclusive".to_string(),
+        ));
+    }
+
+    let effective_mode = if upvoted_flag { "upvoted" } else { mode_str };
+
+    // Parse listing-type and time-filter (only meaningful in feed mode)
+    let listing_type_str =
+        matches.get_one::<String>("listing_type").map(|s| s.as_str()).unwrap_or("hot");
+    let time_filter_str =
+        matches.get_one::<String>("time_filter").map(|s| s.as_str()).unwrap_or("all");
+
+    // Validate that listing-type / time-filter are not used outside feed mode.
+    // We detect "explicit" use by checking whether the value differs from the default.
+    if effective_mode != "feed" {
+        let listing_type_explicit =
+            matches.get_one::<String>("listing_type").map(|s| s.as_str()) != Some("hot")
+                && matches.value_source("listing_type")
+                    == Some(clap::parser::ValueSource::CommandLine);
+        let time_filter_explicit =
+            matches.get_one::<String>("time_filter").map(|s| s.as_str()) != Some("all")
+                && matches.value_source("time_filter")
+                    == Some(clap::parser::ValueSource::CommandLine);
+
+        if listing_type_explicit {
+            return Err(ReddSaverError::InvalidArgument(
+                "--listing-type is only valid with --mode feed".to_string(),
+            ));
+        }
+        if time_filter_explicit {
+            return Err(ReddSaverError::InvalidArgument(
+                "--time-filter is only valid with --mode feed".to_string(),
+            ));
+        }
+    }
+
+    // In feed mode, --subreddits is required
+    if effective_mode == "feed" && subreddits.is_none() {
+        return Err(ReddSaverError::InvalidArgument(
+            "--mode feed requires at least one subreddit via --subreddits".to_string(),
+        ));
+    }
+
+    // Determine effective limit
+    let explicit_limit: Option<usize> = matches.get_one::<usize>("limit").copied();
+    let effective_limit: Option<usize> = match effective_mode {
+        "feed" => Some(explicit_limit.unwrap_or(1000)),
+        _ => explicit_limit, // None means unlimited for saved/upvoted
+    };
+
+    let sort = match listing_type_str {
+        "top" => SubredditSort::Top,
+        "new" => SubredditSort::New,
+        "controversial" => SubredditSort::Controversial,
+        _ => SubredditSort::Hot,
+    };
+
+    let period: Option<TimePeriod> = match listing_type_str {
+        "top" | "controversial" => Some(match time_filter_str {
+            "hour" => TimePeriod::Hour,
+            "day" => TimePeriod::Day,
+            "week" => TimePeriod::Week,
+            "month" => TimePeriod::Month,
+            "year" => TimePeriod::Year,
+            _ => TimePeriod::All,
+        }),
+        _ => None,
+    };
 
     let required_env = load_required_env()?;
     let client_id = required_env.client_id;
@@ -136,7 +244,13 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
         info!("REDDSAVER_PASSWORD = {}", mask_sensitive(&password));
         info!("USER_AGENT = {}", &user_agent);
         info!("SUBREDDITS = {}", print_subreddits(&subreddits));
-        info!("UPVOTED = {}", upvoted);
+        info!("MODE = {}", effective_mode);
+        info!("LISTING_TYPE = {}", listing_type_str);
+        info!("TIME_FILTER = {}", time_filter_str);
+        info!(
+            "LIMIT = {}",
+            effective_limit.map(|n| n.to_string()).unwrap_or_else(|| "unlimited".to_string())
+        );
         info!("FFMPEG AVAILABLE = {}", ffmpeg_available);
         info!("YT-DLP AVAILABLE = {}", ytdlp_available);
 
@@ -175,14 +289,38 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     info!("Link Karma: {:#?}", user_info.data.link_karma);
 
     info!("Starting data gathering from Reddit. This might take some time. Hold on....");
-    // get the saved/upvoted posts for this particular user
-    let listing = user.listing(listing_type).await?;
+
+    let (listing, downloader_subreddits) = match effective_mode {
+        "feed" => {
+            let subreddits_list = subreddits.as_ref().unwrap();
+            let limit = effective_limit.unwrap(); // always Some in subreddit mode
+            let mut all_listings = Vec::new();
+            for sub in subreddits_list {
+                info!("Fetching r/{} ({}, limit {})", sub, sort, limit);
+                let mut sub_listing =
+                    user.subreddit_listing(sub, &sort, period.as_ref(), limit).await?;
+                all_listings.append(&mut sub_listing);
+            }
+            // subreddits filter not needed — we already fetched per-subreddit
+            (all_listings, None)
+        }
+        _ => {
+            let listing_type = if effective_mode == "upvoted" {
+                ListingType::Upvoted
+            } else {
+                ListingType::Saved
+            };
+            let listing = user.listing(&listing_type, effective_limit).await?;
+            (listing, subreddits)
+        }
+    };
+
     debug!("Posts: {:#?}", listing);
 
     let downloader = Downloader::new(
         &listing,
         &data_directory,
-        &subreddits,
+        &downloader_subreddits,
         should_download,
         ffmpeg_available,
         ytdlp_available,

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn cli() -> Command {
                 .short('t')
                 .long("listing-type")
                 .value_name("TYPE")
-                .value_parser(["hot", "top", "new", "controversial"])
+                .value_parser(clap::value_parser!(SubredditSort))
                 .default_value("hot")
                 .help("Subreddit listing sort"),
         )
@@ -113,7 +113,7 @@ fn cli() -> Command {
                 .short('T')
                 .long("time-filter")
                 .value_name("PERIOD")
-                .value_parser(["hour", "day", "week", "month", "year", "all"])
+                .value_parser(clap::value_parser!(TimePeriod))
                 .default_value("all")
                 .help("Time period for top/controversial listings"),
         )
@@ -145,17 +145,15 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
     let effective_mode = matches.get_one::<String>("mode").map(|s| s.as_str()).unwrap_or("saved");
 
     // Parse listing-type and time-filter (only meaningful in feed mode)
-    let listing_type_str =
-        matches.get_one::<String>("listing_type").map(|s| s.as_str()).unwrap_or("hot");
-    let time_filter_str =
-        matches.get_one::<String>("time_filter").map(|s| s.as_str()).unwrap_or("all");
+    let listing_type = matches.get_one::<SubredditSort>("listing_type").cloned().unwrap_or(SubredditSort::Hot);
+    let time_filter = matches.get_one::<TimePeriod>("time_filter").cloned().unwrap_or(TimePeriod::All);
 
     // Validate that listing-type / time-filter are not used outside feed mode.
     // We detect "explicit" use by checking whether the value differs from the default.
     if effective_mode != "feed" {
-        let listing_type_explicit = listing_type_str != "hot"
+        let listing_type_explicit = listing_type != SubredditSort::Hot
             && matches.value_source("listing_type") == Some(clap::parser::ValueSource::CommandLine);
-        let time_filter_explicit = time_filter_str != "all"
+        let time_filter_explicit = time_filter != TimePeriod::All
             && matches.value_source("time_filter") == Some(clap::parser::ValueSource::CommandLine);
 
         if listing_type_explicit {
@@ -184,22 +182,8 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
         _ => explicit_limit, // None means unlimited for saved/upvoted
     };
 
-    let sort = match listing_type_str {
-        "top" => SubredditSort::Top,
-        "new" => SubredditSort::New,
-        "controversial" => SubredditSort::Controversial,
-        _ => SubredditSort::Hot,
-    };
-
-    let period: Option<TimePeriod> = match listing_type_str {
-        "top" | "controversial" => Some(match time_filter_str {
-            "hour" => TimePeriod::Hour,
-            "day" => TimePeriod::Day,
-            "week" => TimePeriod::Week,
-            "month" => TimePeriod::Month,
-            "year" => TimePeriod::Year,
-            _ => TimePeriod::All,
-        }),
+    let period = match listing_type {
+        SubredditSort::Top | SubredditSort::Controversial => Some(&time_filter),
         _ => None,
     };
 
@@ -224,8 +208,8 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
         info!("USER_AGENT = {}", &user_agent);
         info!("SUBREDDITS = {}", print_subreddits(&subreddits));
         info!("MODE = {}", effective_mode);
-        info!("LISTING_TYPE = {}", listing_type_str);
-        info!("TIME_FILTER = {}", time_filter_str);
+        info!("LISTING_TYPE = {}", listing_type);
+        info!("TIME_FILTER = {}", time_filter);
         info!(
             "LIMIT = {}",
             effective_limit.map(|n| n.to_string()).unwrap_or_else(|| "unlimited".to_string())
@@ -275,9 +259,9 @@ async fn run(matches: ArgMatches) -> Result<(), ReddSaverError> {
             let limit = effective_limit.unwrap(); // always Some in subreddit mode
             let mut all_listings = Vec::new();
             for sub in subreddits_list {
-                info!("Fetching r/{} ({}, limit {})", sub, sort, limit);
+                info!("Fetching r/{} ({}, limit {})", sub, listing_type, limit);
                 let mut sub_listing =
-                    user.subreddit_listing(sub, &sort, period.as_ref(), limit).await?;
+                    user.subreddit_listing(sub, &listing_type, period, limit).await?;
                 all_listings.append(&mut sub_listing);
             }
             // subreddits filter not needed — we already fetched per-subreddit

--- a/src/user.rs
+++ b/src/user.rs
@@ -31,7 +31,7 @@ impl Display for ListingType {
 }
 
 /// Sort order for subreddit feed listings.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
 pub enum SubredditSort {
     Hot,
     Top,
@@ -51,7 +51,7 @@ impl Display for SubredditSort {
 }
 
 /// Time period filter for top/controversial subreddit listings.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
 pub enum TimePeriod {
     Hour,
     Day,

--- a/src/user.rs
+++ b/src/user.rs
@@ -52,6 +52,8 @@ impl Display for Mode {
 #[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
 pub enum SubredditSort {
     Hot,
+    Best,
+    Rising,
     Top,
     New,
     Controversial,
@@ -61,6 +63,8 @@ impl Display for SubredditSort {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             SubredditSort::Hot => write!(f, "hot"),
+            SubredditSort::Best => write!(f, "best"),
+            SubredditSort::Rising => write!(f, "rising"),
             SubredditSort::Top => write!(f, "top"),
             SubredditSort::New => write!(f, "new"),
             SubredditSort::Controversial => write!(f, "controversial"),
@@ -191,7 +195,7 @@ impl<'a> User<'a> {
 
     /// Fetch posts from a subreddit's feed.
     ///
-    /// `sort` selects the listing type (hot, top, new, controversial).
+    /// `sort` selects the listing type (hot, best, rising, top, new, controversial).
     /// `period` applies a time filter for `top` and `controversial` sorts.
     /// `limit` caps the total number of posts returned (per subreddit).
     pub async fn subreddit_listing(

--- a/src/user.rs
+++ b/src/user.rs
@@ -30,6 +30,50 @@ impl Display for ListingType {
     }
 }
 
+/// Sort order for subreddit feed listings.
+#[derive(Debug)]
+pub enum SubredditSort {
+    Hot,
+    Top,
+    New,
+    Controversial,
+}
+
+impl Display for SubredditSort {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            SubredditSort::Hot => write!(f, "hot"),
+            SubredditSort::Top => write!(f, "top"),
+            SubredditSort::New => write!(f, "new"),
+            SubredditSort::Controversial => write!(f, "controversial"),
+        }
+    }
+}
+
+/// Time period filter for top/controversial subreddit listings.
+#[derive(Debug)]
+pub enum TimePeriod {
+    Hour,
+    Day,
+    Week,
+    Month,
+    Year,
+    All,
+}
+
+impl Display for TimePeriod {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            TimePeriod::Hour => write!(f, "hour"),
+            TimePeriod::Day => write!(f, "day"),
+            TimePeriod::Week => write!(f, "week"),
+            TimePeriod::Month => write!(f, "month"),
+            TimePeriod::Year => write!(f, "year"),
+            TimePeriod::All => write!(f, "all"),
+        }
+    }
+}
+
 impl<'a> User<'a> {
     pub fn new(auth: &'a Auth, name: &'a str) -> Self {
         User { auth, name }
@@ -55,14 +99,19 @@ impl<'a> User<'a> {
         Ok(response)
     }
 
+    /// Fetch saved or upvoted posts for the authenticated user.
+    ///
+    /// `limit` caps the total number of posts returned. Pass `None` to fetch all
+    /// available posts (the original behaviour).
     pub async fn listing(
         &self,
         listing_type: &ListingType,
+        limit: Option<usize>,
     ) -> Result<Vec<Listing>, ReddSaverError> {
         let client = reqwest::Client::new();
 
         let mut complete = false;
-        let mut processed = 0;
+        let mut processed: usize = 0;
         let mut after: Option<String> = None;
         let mut listing: Vec<Listing> = Vec::new();
         while !complete {
@@ -80,7 +129,7 @@ impl<'a> User<'a> {
                 )
             };
 
-            let response = client
+            let mut response = client
                 .get(&url)
                 .bearer_auth(&self.auth.access_token)
                 .header(USER_AGENT, get_user_agent_string(None, None))
@@ -91,15 +140,100 @@ impl<'a> User<'a> {
                 .json::<Listing>()
                 .await?;
 
-            // total number of items processed by the method
-            // note that not all of these items are media, so the downloaded media will be
-            // lesser than or equal to the number of items present
-            processed += response.data.dist;
+            let page_count = response.data.dist as usize;
+
+            // if a limit is set and this page would exceed it, trim the children
+            if let Some(cap) = limit {
+                let remaining = cap.saturating_sub(processed);
+                if page_count > remaining {
+                    response.data.children.truncate(remaining);
+                    response.data.dist = remaining as i32;
+                }
+            }
+
+            processed += response.data.dist as usize;
             info!("Number of items processed : {}", processed);
 
+            let hit_limit = limit.map(|cap| processed >= cap).unwrap_or(false);
+
             // if there is a response, continue collecting them into a vector
-            if response.data.after.as_ref().is_none() {
+            if response.data.after.as_ref().is_none() || hit_limit {
                 info!("Data gathering complete. Yay.");
+                listing.push(response);
+                complete = true;
+            } else {
+                debug!("Processing till: {}", response.data.after.as_ref().unwrap());
+                after = response.data.after.clone();
+                listing.push(response);
+            }
+        }
+
+        Ok(listing)
+    }
+
+    /// Fetch posts from a subreddit's feed.
+    ///
+    /// `sort` selects the listing type (hot, top, new, controversial).
+    /// `period` applies a time filter for `top` and `controversial` sorts.
+    /// `limit` caps the total number of posts returned (per subreddit).
+    pub async fn subreddit_listing(
+        &self,
+        subreddit: &str,
+        sort: &SubredditSort,
+        period: Option<&TimePeriod>,
+        limit: usize,
+    ) -> Result<Vec<Listing>, ReddSaverError> {
+        let client = reqwest::Client::new();
+
+        let mut complete = false;
+        let mut processed: usize = 0;
+        let mut after: Option<String> = None;
+        let mut listing: Vec<Listing> = Vec::new();
+
+        while !complete {
+            let base_url = if processed == 0 {
+                format!("https://oauth.reddit.com/r/{}/{}", subreddit, sort)
+            } else {
+                format!(
+                    "https://oauth.reddit.com/r/{}/{}?after={}",
+                    subreddit,
+                    sort,
+                    after.as_ref().unwrap()
+                )
+            };
+
+            let mut request = client
+                .get(&base_url)
+                .bearer_auth(&self.auth.access_token)
+                .header(USER_AGENT, get_user_agent_string(None, None))
+                .query(&[("limit", "100")]);
+
+            // top and controversial support an optional time period filter
+            if let Some(p) = period {
+                match sort {
+                    SubredditSort::Top | SubredditSort::Controversial => {
+                        request = request.query(&[("t", p.to_string())]);
+                    }
+                    _ => {}
+                }
+            }
+
+            let mut response = request.send().await?.json::<Listing>().await?;
+
+            let page_count = response.data.dist as usize;
+            let remaining = limit.saturating_sub(processed);
+            if page_count > remaining {
+                response.data.children.truncate(remaining);
+                response.data.dist = remaining as i32;
+            }
+
+            processed += response.data.dist as usize;
+            info!("Number of items processed from r/{}: {}", subreddit, processed);
+
+            let hit_limit = processed >= limit;
+
+            if response.data.after.as_ref().is_none() || hit_limit {
+                info!("Data gathering complete for r/{}.", subreddit);
                 listing.push(response);
                 complete = true;
             } else {

--- a/src/user.rs
+++ b/src/user.rs
@@ -30,6 +30,24 @@ impl Display for ListingType {
     }
 }
 
+/// Top-level operation mode selected via --mode.
+#[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
+pub enum Mode {
+    Saved,
+    Upvoted,
+    Feed,
+}
+
+impl Display for Mode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Mode::Saved => write!(f, "saved"),
+            Mode::Upvoted => write!(f, "upvoted"),
+            Mode::Feed => write!(f, "feed"),
+        }
+    }
+}
+
 /// Sort order for subreddit feed listings.
 #[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
 pub enum SubredditSort {


### PR DESCRIPTION
## Summary

- Adds `--mode feed` to download media from a subreddit's own listing feed (hot, top, new, controversial) rather than the authenticated user's saved or upvoted posts
- Adds `--listing-type` and `--time-filter` flags to control the feed sort and time period (feed mode only)
- Adds `--limit` flag to cap the number of posts processed per source; defaults to unlimited for `saved`/`upvoted` and **1000 per subreddit** for `feed`
- Keeps `--upvoted` as a backwards-compatible alias for `--mode upvoted`; all existing invocations continue to work unchanged

## New flags

| Flag | Short | Values | Default |
|------|-------|--------|---------|
| `--mode` | `-m` | `saved`, `upvoted`, `feed` | `saved` |
| `--listing-type` | `-t` | `hot`, `top`, `new`, `controversial` | `hot` |
| `--time-filter` | `-T` | `hour`, `day`, `week`, `month`, `year`, `all` | `all` |
| `--limit` | `-l` | positive integer | unlimited / 1000 |

## Implementation notes

- `src/user.rs` — new `SubredditSort` and `TimePeriod` enums; `listing()` gains an optional `limit` parameter; new `subreddit_listing()` method that hits `oauth.reddit.com/r/{sub}/{sort}` with the same cursor-based pagination as the existing user listing, exiting early once the limit is reached
- `src/main.rs` — new CLI args, mode resolution logic, runtime validation (feed requires `--subreddits`; `--listing-type`/`--time-filter` error outside feed mode; `--upvoted` + `--mode feed` is rejected), and branching in `run()` to route to the appropriate listing function
- `src/errors.rs` — new `InvalidArgument(String)` variant for clean CLI validation errors
- `README.md` — updated tagline, usage examples, command reference, modes table, and feed mode options table

## Test plan

- [ ] `reddsaver -e reddsaver.env -d data` — saved mode still works
- [ ] `reddsaver -e reddsaver.env -d data --upvoted` — upvoted alias still works
- [ ] `reddsaver -e reddsaver.env -d data --mode feed --subreddits pics` — hot feed, default limit 1000
- [ ] `reddsaver -e reddsaver.env -d data --mode feed --subreddits pics,aww --listing-type top --time-filter week --limit 500` — top-of-week, 500 per subreddit
- [ ] `reddsaver -e reddsaver.env -d data --mode feed --subreddits earthporn --listing-type new` — new posts
- [ ] `reddsaver -e reddsaver.env -d data --mode feed --subreddits pics --listing-type controversial --time-filter month` — controversial
- [ ] `reddsaver -e reddsaver.env -d data --limit 200` — limit applies to saved mode
- [ ] `reddsaver --mode feed` — errors with missing `--subreddits`
- [ ] `reddsaver --listing-type hot` — errors when used outside feed mode
- [ ] `reddsaver --upvoted --mode feed` — errors as mutually exclusive