### PR TITLE
Fix RedGifs URL regex to support v3 numeric IDs

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ lazy_static! {
     static ref RG_RE_OLD: Regex =
         Regex::new(r"/([A-Za-z]+)-mobile\.mp4").expect("valid regex");
     static ref RG_RE_NEW: Regex =
-        Regex::new(r"/(?:watch/)?([A-Za-z]+)(?:[^/]*)$").expect("valid regex");
+        Regex::new(r"/(?:watch/)?([A-Za-z0-9]+)(?:[^/]*)$").expect("valid regex");
 }
 
 // RedGifs requires the same User-Agent for both token fetch and media fetch calls


### PR DESCRIPTION
## Summary
- The v3.redgifs.com frontend uses numeric IDs (e.g. `809524136030867385`) instead of the traditional alphabetic slugs (e.g. `SourExcellentJellyfish`)
- The existing regex `[A-Za-z]+` silently failed to capture these numeric IDs, causing downloads to be skipped
- Widened the regex to `[A-Za-z0-9]+` so numeric IDs are properly extracted and passed to the existing v2 API endpoint, which already handles them

## Test plan
- [x] `cargo check` passes
- [x] All 11 existing tests pass
- [x] Manually test downloading a post with a v3 numeric RedGifs URL