### PR TITLE
Fix all cargo clippy warnings

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -41,11 +41,11 @@ impl<'a> Client<'a> {
         agent: &'a str,
     ) -> Self {
         Self {
-            client_id: &id,
-            client_secret: &secret,
-            username: &username,
-            password: &password,
-            user_agent: &agent,
+            client_id: id,
+            client_secret: secret,
+            username,
+            password,
+            user_agent: agent,
         }
     }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -190,11 +190,7 @@ impl<'a> Downloader<'a> {
                         PostMetadata { subreddit, author: post_author, id: post_id };
 
                     let is_valid = if let Some(s) = self.subreddits.as_ref() {
-                        if s.contains(&subreddit) {
-                            true
-                        } else {
-                            false
-                        }
+                        s.contains(&subreddit)
                     } else {
                         true
                     };
@@ -327,7 +323,7 @@ impl<'a> Downloader<'a> {
     /// Helper function to download reddit videos
     async fn download_reddit_video(
         &self,
-        media_urls: &Vec<String>,
+        media_urls: &[String],
         media_type: MediaType,
         post_metadata: &PostMetadata<'_>,
     ) -> Result<(i32, i32), ReddSaverError> {
@@ -340,7 +336,7 @@ impl<'a> Downloader<'a> {
         for (index, url) in media_urls.iter().enumerate() {
             let mut item_index = format!("{}", index);
             let mut extension =
-                String::from(url.split('.').last().unwrap_or("unknown")).replace("/", "_");
+                String::from(url.split('.').next_back().unwrap_or("unknown")).replace("/", "_");
 
             // if the media is a reddit video, they have separate audio and video components.
             // to differentiate this from albums, which use the regular _0, _1, etc indices,
@@ -357,7 +353,7 @@ impl<'a> Downloader<'a> {
             {
                 extension = format!("{}.{}", extension, ".mp4");
             }
-            let file_name = self.generate_file_name(&url, &extension, &item_index, post_metadata);
+            let file_name = self.generate_file_name(url, &extension, &item_index, post_metadata);
 
             if self.should_download {
                 let status = save_or_skip(url, &file_name);
@@ -392,7 +388,7 @@ impl<'a> Downloader<'a> {
             if self.ffmpeg_available {
                 debug!("Assembling components together");
                 let first_url = media_urls.first().expect("checked len == 2");
-                let extension = String::from(first_url.split('.').last().unwrap_or("unknown"));
+                let extension = String::from(first_url.split('.').next_back().unwrap_or("unknown"));
                 // this generates the name of the media without the component indices
                 // this file name is used for saving the ffmpeg combined file
                 let combined_file_name =
@@ -454,7 +450,7 @@ impl<'a> Downloader<'a> {
             debug!("Skipping combining reddit video.");
         }
 
-        return Ok((media_downloaded, media_skipped));
+        Ok((media_downloaded, media_skipped))
     }
 
     /// Helper function to download youtube videos
@@ -468,7 +464,7 @@ impl<'a> Downloader<'a> {
 
         if self.should_download {
             if self.ytdlp_available {
-                let file_name = self.generate_file_name(&media_url, "mp4", "0", post_metadata);
+                let file_name = self.generate_file_name(media_url, "mp4", "0", post_metadata);
 
                 if check_path_present(&file_name) {
                     debug!("Youtube video from url {} already downloaded. Skipping...", media_url);
@@ -510,7 +506,7 @@ impl<'a> Downloader<'a> {
             media_skipped += 1;
         }
 
-        return Ok((media_downloaded, media_skipped));
+        Ok((media_downloaded, media_skipped))
     }
 
     /// Helper function to download other media
@@ -527,13 +523,13 @@ impl<'a> Downloader<'a> {
         let extension = if media_type == MediaType::RedgifsVideo {
             String::from("mp4")
         } else {
-            String::from(media_url.split('.').last().unwrap_or("unknown")).replace("/", "_")
+            String::from(media_url.split('.').next_back().unwrap_or("unknown")).replace("/", "_")
         };
 
-        let file_name = self.generate_file_name(&media_url, &extension, &index, post_metadata);
+        let file_name = self.generate_file_name(media_url, &extension, index, post_metadata);
 
         if self.should_download {
-            let status = save_or_skip(&*media_url, &file_name);
+            let status = save_or_skip(media_url, &file_name);
             // update the summary statistics based on the status
             match status.await? {
                 MediaStatus::Downloaded => {
@@ -548,17 +544,17 @@ impl<'a> Downloader<'a> {
             media_skipped += 1;
         }
 
-        return Ok((media_downloaded, media_skipped));
+        Ok((media_downloaded, media_skipped))
     }
 }
 
 /// Helper function that downloads and saves a single media from Reddit or Imgur
 async fn save_or_skip(url: &str, file_name: &str) -> Result<MediaStatus, ReddSaverError> {
-    if check_path_present(&file_name) {
+    if check_path_present(file_name) {
         debug!("Media from url {} already downloaded. Skipping...", url);
         Ok(MediaStatus::Skipped)
     } else {
-        let save_status = download_media(&file_name, &url).await?;
+        let save_status = download_media(file_name, url).await?;
         if save_status {
             Ok(MediaStatus::Downloaded)
         } else {
@@ -604,7 +600,7 @@ async fn download_media(file_name: &str, url: &str) -> Result<bool, ReddSaverErr
             let maybe_data = response.bytes().await;
             if let Ok(data) = maybe_data {
                 debug!("Bytes length of the data: {:#?}", data.len());
-                let maybe_output = File::create(&file_name);
+                let maybe_output = File::create(file_name);
                 match maybe_output {
                     Ok(mut output) => {
                         debug!("Created a file: {}", file_name);
@@ -668,7 +664,7 @@ async fn get_reddit_video(url: &str) -> Result<Option<SupportedMedia>, ReddSaver
     if let Some(dash_video) = maybe_dash_video {
         let present = dash_video.contains("DASH");
         // todo: find exhaustive collection of these, or figure out if they are (x, x*2) pairs
-        let dash_video_only = vec!["DASH_1_2_M", "DASH_2_4_M", "DASH_4_8_M"];
+        let dash_video_only = ["DASH_1_2_M", "DASH_2_4_M", "DASH_4_8_M"];
         if present {
             return if dash_video_only.contains(&dash_video) {
                 let supported_media = SupportedMedia {
@@ -804,7 +800,7 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
                         .and_then(|mm| mm.get(&item.media_id))
                         .and_then(|v| v.get("m"))
                         .and_then(|m| m.as_str())
-                        .and_then(|mime| mime.split('/').last())
+                        .and_then(|mime| mime.split('/').next_back())
                         .map(|sub| if sub == "jpeg" { "jpg" } else { sub })
                         .unwrap_or("jpg");
                     let image_url = format!(
@@ -827,10 +823,8 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
                     media_type: MediaType::GfycatGif,
                 };
                 media.push(supported_media);
-            } else {
-                if let Some(supported_media) = gfy_to_mp4(url).await? {
-                    media.push(supported_media);
-                }
+            } else if let Some(supported_media) = gfy_to_mp4(url).await? {
+                media.push(supported_media);
             }
         }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -142,7 +142,7 @@ impl<'a> User<'a> {
             // during the first call to the API, we would not provide the after query parameter
             // in subsequent calls, we use the value for after from the response of the
             //  previous request and continue doing so till the value of after is null
-            let base_url = format!("https://oauth.reddit.com/user/{}/{}", self.name, listing_type.to_string());
+            let base_url = format!("https://oauth.reddit.com/user/{}/{}", self.name, listing_type);
 
             let mut request = client
                 .get(&base_url)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -47,7 +47,7 @@ pub fn check_path_present(file_path: &str) -> bool {
 /// Function that masks sensitive data such as password and client secrets
 pub fn mask_sensitive(word: &str) -> String {
     let word_length = word.len();
-    return if word.is_empty() {
+    if word.is_empty() {
         // return with indication if string is empty
         String::from("<EMPTY>")
     } else if word_length > 0 && word_length <= 3 {
@@ -60,21 +60,18 @@ pub fn mask_sensitive(word: &str) -> String {
             .enumerate()
             .map(|(i, c)| if i == 0 || i == 1 || i == word_length - 1 { c } else { '*' })
             .collect()
-    };
+    }
 }
 
 /// Return delimited subreddit names or EMPTY if None
 pub fn print_subreddits(subreddits: &Option<Vec<&str>>) -> String {
-    return if let Some(s) = subreddits { s.join(",") } else { String::from("<ALL>") };
+    if let Some(s) = subreddits { s.join(",") } else { String::from("<ALL>") }
 }
 
 /// Check if the given application is present in the $PATH
 pub fn application_present(name: String) -> bool {
     let result = which(name);
-    match result {
-        Ok(_) => true,
-        _ => false,
-    }
+    result.is_ok()
 }
 
 /// Fetch a temporary bearer token from the RedGifs v2 auth endpoint


### PR DESCRIPTION
## Summary
- Resolve all 32 `cargo clippy` warnings across `src/auth.rs`, `src/download.rs`, `src/user.rs`, and `src/utils.rs`
- Fixes include: removing needless borrows/returns, simplifying bool expressions, using `&[String]` instead of `&Vec<String>`, replacing `.last()` with `.next_back()` on double-ended iterators, collapsing else-if blocks, using array literals instead of `vec!`, and applying struct field shorthand

## Test plan
- [x] `cargo clippy` produces zero warnings
- [x] `cargo build` succeeds
- [x] `cargo test` — all 11 tests pass