### PR TITLE
Add ARM64 builds and adopt JReleaser for releases

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,31 +22,51 @@ jobs:
         with:
           command: check
 
-  publish:
+  precheck:
     if: startsWith(github.ref, 'refs/tags/')
-    name: Publish for ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.vars.outputs.VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Version
+        id: vars
+        shell: bash
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
+          echo ::set-output name=VERSION::$(echo "$version")
+
+  publish:
+    needs: [ precheck ]
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: true
       matrix:
-        name: [
-            linux,
-            windows,
-            macos
-        ]
-
         include:
-          - name: linux
+          - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact_name: target/release/reddsaver
-            asset_name: reddsaver-linux-amd64
-          - name: windows
-            os: windows-latest
-            artifact_name: target/release/reddsaver.exe
-            asset_name: reddsaver-windows-amd64
-          - name: macos
+            use-cross: false
+            jreleaser_platform: linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            use-cross: true
+            jreleaser_platform: linux-aarch_64
+          - target: x86_64-apple-darwin
             os: macos-latest
-            artifact_name: target/release/reddsaver
-            asset_name: reddsaver-macos-amd64
+            use-cross: false
+            jreleaser_platform: osx-x86_64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            use-cross: false
+            jreleaser_platform: osx-aarch_64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            use-cross: false
+            jreleaser_platform: windows-x86_64
 
     steps:
       - name: Checkout repository
@@ -57,15 +77,68 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
 
       - name: Build
-        run: cargo build --release --locked
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: actions-rs/cargo@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
-          tag: ${{ github.ref }}
-          overwrite: true
+          use-cross: ${{ matrix.use-cross }}
+          command: build
+          args: --locked --release --target=${{ matrix.target }}
+
+      - name: Assemble
+        uses: jreleaser/release-action@v2
+        with:
+          version: early-access
+          arguments: assemble
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ needs.precheck.outputs.VERSION }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PLATFORM_OVERRIDE: ${{ matrix.jreleaser_platform }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          retention-days: 1
+          name: artifacts
+          path: |
+            out/jreleaser/assemble/reddsaver/archive/*.zip
+
+      - name: JReleaser output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jreleaser-output-${{ matrix.target }}
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties
+
+  release:
+    needs: [ precheck, publish ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Release
+        uses: jreleaser/release-action@v2
+        with:
+          version: early-access
+          arguments: full-release -PartifactsDir=artifacts -PskipArchiveResolver
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ needs.precheck.outputs.VERSION }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: JReleaser output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: output-release-logs
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,65 @@
+environment:
+  properties:
+    artifactsDir: out/jreleaser/assemble/reddsaver/archive
+
+project:
+  name: reddsaver
+  description: CLI tool to download saved media from Reddit
+  longDescription: CLI tool to download saved and upvoted media from Reddit
+  website: https://github.com/manojkarthick/reddsaver
+  authors:
+    - Manoj Karthick
+  license: MIT
+  extraProperties:
+    inceptionYear: 2020
+
+platform:
+  replacements:
+    'osx-x86_64': 'x86_64-apple-darwin'
+    'osx-aarch_64': 'aarch64-apple-darwin'
+    'linux-x86_64': 'x86_64-unknown-linux-gnu'
+    'linux-aarch_64': 'aarch64-unknown-linux-gnu'
+    'windows-x86_64': 'x86_64-pc-windows-msvc'
+
+release:
+  github:
+    name: reddsaver
+    overwrite: true
+    branch: master
+    changelog:
+      formatted: ALWAYS
+      format: '- {{commitShortHash}} {{commitTitle}}'
+      preset: conventional-commits
+      contributors:
+        enabled: false
+
+assemble:
+  archive:
+    reddsaver:
+      active: ALWAYS
+      formats:
+        - ZIP
+      attachPlatform: true
+      fileSets:
+        - input: 'target/{{ osPlatformReplaced }}/release'
+          output: 'bin'
+          includes: [ 'reddsaver{.exe,}' ]
+        - input: '.'
+          includes: [ 'LICENSE-MIT', 'LICENSE-APACHE' ]
+
+distributions:
+  reddsaver:
+    type: BINARY
+    executable:
+      windowsExtension: exe
+    artifacts:
+      - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-x86_64-apple-darwin.zip'
+        platform: 'osx-x86_64'
+      - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-aarch64-apple-darwin.zip'
+        platform: 'osx-aarch_64'
+      - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-x86_64-unknown-linux-gnu.zip'
+        platform: 'linux-x86_64'
+      - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-aarch64-unknown-linux-gnu.zip'
+        platform: 'linux-aarch_64'
+      - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-x86_64-pc-windows-msvc.zip'
+        platform: 'windows-x86_64'


### PR DESCRIPTION
## Summary
- Add `aarch64-unknown-linux-gnu` and `aarch64-apple-darwin` targets to the release workflow, enabling ARM64 binaries for Linux and macOS (Apple Silicon)
- Replace `svenstaro/upload-release-action` with JReleaser for release management, matching the pattern used in [pqrs](https://github.com/manojkarthick/pqrs)
- Linux ARM64 is cross-compiled using `cross` via `actions-rs/cargo`'s `use-cross` flag; macOS ARM64 builds natively from the Intel runner

## Changes
- `.github/workflows/rust.yml` — restructured publish job with target triples, added `precheck` and `release` jobs
- `jreleaser.yml` — new JReleaser config for assembling ZIP archives and creating GitHub releases with conventional-commits changelog

## Test plan
- [ ] Push a tag (e.g., `v1.0.0-rc4`) and verify the release has 5 ZIP assets covering all targets
- [ ] Verify the changelog is auto-generated from conventional commits