### PR TITLE
fix: apply GIF-to-MP4 conversion for gallery posts

### DIFF
--- a/scripts/download_top_presets.sh
+++ b/scripts/download_top_presets.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# download_top_presets.sh — Download common top-listing presets for one subreddit.
+#
+# Usage:
+#   ./scripts/download_top_presets.sh --env-file <env-file> --subreddit <subreddit> --data-dir <data-dir>
+#
+# Runs:
+#   - top/all   limit 1000
+#   - top/year  limit 500
+#   - top/month limit 250
+#   - top/day   limit 25
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --env-file <env-file> --subreddit <subreddit> --data-dir <data-dir>" >&2
+    exit 1
+}
+
+env_file=""
+subreddit=""
+data_dir=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env-file)
+            [[ $# -ge 2 ]] || usage
+            env_file="$2"
+            shift 2
+            ;;
+        --subreddit)
+            [[ $# -ge 2 ]] || usage
+            subreddit="$2"
+            shift 2
+            ;;
+        --data-dir)
+            [[ $# -ge 2 ]] || usage
+            data_dir="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+[[ -n "$env_file" && -n "$subreddit" && -n "$data_dir" ]] || usage
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+if command -v reddsaver >/dev/null 2>&1; then
+    reddsaver_bin="reddsaver"
+elif [[ -x "${repo_root}/target/release/reddsaver" ]]; then
+    reddsaver_bin="${repo_root}/target/release/reddsaver"
+else
+    echo "Error: could not find 'reddsaver' in PATH or under target/release." >&2
+    exit 1
+fi
+
+if [[ ! -f "$env_file" ]]; then
+    echo "Error: env file not found: $env_file" >&2
+    exit 1
+fi
+
+run_preset() {
+    local period="$1"
+    local limit="$2"
+
+    echo "Running top/${period} for r/${subreddit} (limit ${limit})"
+    "$reddsaver_bin" \
+        --from-env "$env_file" \
+        --mode feed \
+        --listing-type top \
+        --time-filter "$period" \
+        --subreddits "$subreddit" \
+        --limit "$limit" \
+        --data-dir "$data_dir"
+}
+
+run_preset all 1000
+run_preset year 500
+run_preset month 250
+run_preset day 25

--- a/src/download.rs
+++ b/src/download.rs
@@ -849,11 +849,14 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
         // reddit image galleries
         if url.contains(REDDIT_DOMAIN) && url.contains(REDDIT_GALLERY_PATH) {
             if let Some(gallery) = gallery_info {
-                // collect all the URLs for the images in the album
+                // collect all the URLs for the images in the album, separating
+                // GIFs from other image types so GIFs go through the MP4 conversion path
                 let mut image_urls = Vec::new();
+                let mut gif_urls = Vec::new();
                 for item in gallery.items.iter() {
                     // derive the extension from media_metadata ("m" is the MIME type,
-                    // e.g. "image/jpg", "image/png", "image/webp"). Fall back to "jpg".
+                    // e.g. "image/jpg", "image/png", "image/webp", "image/gif").
+                    // Fall back to "jpg".
                     let ext = data.media_metadata
                         .as_ref()
                         .and_then(|mm| mm.get(&item.media_id))
@@ -862,15 +865,26 @@ async fn get_media(data: &PostData) -> Result<Vec<SupportedMedia>, ReddSaverErro
                         .and_then(|mime| mime.split('/').next_back())
                         .map(|sub| if sub == "jpeg" { "jpg" } else { sub })
                         .unwrap_or("jpg");
-                    let image_url = format!(
+                    let item_url = format!(
                         "https://{}/{}.{}",
                         REDDIT_IMAGE_SUBDOMAIN, item.media_id, ext
                     );
-                    image_urls.push(image_url);
+                    if ext == GIF_EXTENSION {
+                        gif_urls.push(item_url);
+                    } else {
+                        image_urls.push(item_url);
+                    }
                 }
-                let supported_media =
-                    SupportedMedia { components: image_urls, media_type: MediaType::RedditImage };
-                media.push(supported_media);
+                if !image_urls.is_empty() {
+                    let supported_media =
+                        SupportedMedia { components: image_urls, media_type: MediaType::RedditImage };
+                    media.push(supported_media);
+                }
+                if !gif_urls.is_empty() {
+                    let supported_media =
+                        SupportedMedia { components: gif_urls, media_type: MediaType::RedditGif };
+                    media.push(supported_media);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Gallery posts containing GIFs were not being converted to MP4, because all gallery items were classified as `RedditImage` regardless of MIME type
- The GIF-to-MP4 conversion path (introduced in ad53cbe) only triggers for `RedditGif` or `GiphyGif` media types, so gallery GIFs were saved as `.gif` files
- Gallery items are now separated by MIME type: `image/gif` entries are routed as `RedditGif` through the ffmpeg conversion pipeline, while other image types continue as `RedditImage`

## Test plan

- [ ] Run `cargo test` — all 15 tests pass
- [ ] Save a Reddit post containing a gallery with GIF items and verify they are downloaded as `.mp4` files
- [ ] Save a Reddit post containing a gallery with only image items (no GIFs) and verify behavior is unchanged
- [ ] Save a Reddit post containing a gallery with mixed GIFs and images and verify GIFs become `.mp4` while images keep their original format