### PR TITLE
feat: add Homebrew packaging via JReleaser

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -63,3 +63,18 @@ distributions:
         platform: 'linux-aarch_64'
       - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-x86_64-pc-windows-msvc.zip'
         platform: 'windows-x86_64'
+
+packagers:
+  brew:
+    active: ALWAYS
+    continueOnError: false
+    formulaName: Reddsaver
+    multiPlatform: true
+    commitAuthor:
+      name: jreleaserbot
+      email: jreleaser@kordamp.org
+    tap:
+      active: ALWAYS
+      owner: manojkarthick
+      name: homebrew-tap
+      username: manojkarthick


### PR DESCRIPTION
## Summary

- Add `packagers.brew` configuration to `jreleaser.yml` to enable Homebrew distribution
- Configures a multi-arch Homebrew tap published to `manojkarthick/homebrew-tap`
- Uses the `Reddsaver` naming convention and jreleaserbot as the commit author

## Test plan

- [ ] Verify JReleaser dry-run succeeds with the new brew packager config
- [ ] Trigger a release and check that the Homebrew tap repo receives the generated Ruby class
- [ ] Test installation via `brew install manojkarthick/tap/reddsaver`